### PR TITLE
Fixing invalid dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Usage
 -----
 **Pre-Requisites:** You must have a running zookeeper instance in order to start any of the storm daemons. 
 ```
-docker run -p 2181:2181 -p 2888:2888 -p 3888:3888 -h zookeeper –-name="zookeeper" -d jplock/zookeeper;
+docker run -p 2181:2181 -p 2888:2888 -p 3888:3888 -h zookeeper --name="zookeeper" -d jplock/zookeeper;
 ```
 
 The image contains an **ENTRYPOINT** for running one container per storm daemon as follow:


### PR DESCRIPTION
The docker run command given does not work due to an incorrect dash character mixed with a correct dash character on the --name arguement.